### PR TITLE
upgrade version of github-openvpn-connect-action

### DIFF
--- a/openvpn-p81/action.yml
+++ b/openvpn-p81/action.yml
@@ -27,7 +27,7 @@ runs:
       curl -s ${{ inputs.configfile-url }} -o config.ovpn
     shell: bash
   - name: Connect VPN
-    uses: "kota65535/github-openvpn-connect-action@v1"
+    uses: "kota65535/github-openvpn-connect-action@v2.0.2"
     with:
       config_file: ./config.ovpn
       username: ${{ inputs.username }}


### PR DESCRIPTION
This PR upgrades version of kota65535/github-openvpn-connect-action to v2.0.2.